### PR TITLE
Fix dashboard navigation for superadmin in newsroom section

### DIFF
--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -50,8 +50,12 @@ export function AdminLayout({ children }: AdminLayoutProps) {
   const getNavigation = (): (NavigationItem | NavigationSection)[] => {
     const navigation: (NavigationItem | NavigationSection)[] = []
 
-    // Dashboard - always visible to authenticated users
-    navigation.push({ name: 'Dashboard', href: '/admin', icon: HomeIcon })
+    // Dashboard - context-aware based on current path
+    const dashboardHref = pathname.startsWith('/newsroom') && session?.user?.staffRole && 
+      ['EDITOR', 'SUB_EDITOR', 'JOURNALIST', 'INTERN'].includes(session.user.staffRole) 
+      ? '/newsroom' 
+      : '/admin';
+    navigation.push({ name: 'Dashboard', href: dashboardHref, icon: HomeIcon })
 
     // Newsroom section - available to all staff users
     if (session?.user?.userType === 'STAFF') {


### PR DESCRIPTION
- Make dashboard link context-aware based on current path
- Editorial staff in newsroom section will go to /newsroom dashboard
- Admins and superadmins will go to /admin dashboard
- This prevents navigation errors when clicking Dashboard from newsroom

