### PR TITLE
Add catch-all route and enhanced debugging for admin/newsroom detection

### DIFF
--- a/src/app/admin/newsroom/[...path]/page.tsx
+++ b/src/app/admin/newsroom/[...path]/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+
+export default function AdminNewsroomCatchAll() {
+  const router = useRouter();
+  const params = useParams();
+  
+  useEffect(() => {
+    console.log('🚨 CAUGHT: Old admin/newsroom route accessed');
+    console.log('🚨 Path segments:', params.path);
+    console.log('🚨 Full URL:', window.location.href);
+    console.log('🚨 Referrer:', document.referrer);
+    console.log('🚨 User agent:', navigator.userAgent);
+    
+    // Redirect to the new location
+    const newPath = `/newsroom/${Array.isArray(params.path) ? params.path.join('/') : params.path || ''}`;
+    console.log('🚨 Redirecting to:', newPath);
+    router.replace(newPath);
+  }, [params, router]);
+  
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <h2 className="text-lg font-semibold text-gray-900">Redirecting...</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Old route detected, redirecting to new location
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,6 +16,13 @@ const roleBasedPaths = {
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   console.log('🛡️ Middleware - Checking path:', pathname);
+  
+  // Special debugging for the problematic path
+  if (pathname.includes('/admin/newsroom/stories')) {
+    console.log('🚨 FOUND IT! Request to /admin/newsroom/stories detected');
+    console.log('🚨 Request URL:', request.url);
+    console.log('🚨 Request headers:', Object.fromEntries(request.headers.entries()));
+  }
 
   // Allow public paths
   if (publicPaths.includes(pathname)) {


### PR DESCRIPTION
- Create catch-all route at /admin/newsroom/[...path] to intercept old URLs
- Add detailed logging when old path is accessed including referrer and user agent
- Add special middleware debugging for /admin/newsroom/stories requests
- Route will temporarily redirect to new location while logging source

This will help us identify what's generating the old URLs.

🤖 Generated with [Claude Code](https://claude.ai/code)