### PR TITLE
Block /admin/newsroom paths in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,7 @@ const publicPaths = ['/', '/login', '/password-reset', '/dashboard'];
 
 // Paths that require specific roles
 const roleBasedPaths = {
+  '/admin/newsroom': [], // Block this path explicitly - it shouldn't exist
   '/admin': ['SUPERADMIN', 'ADMIN'],
   '/admin/users': ['SUPERADMIN', 'ADMIN'],
   '/admin/stations': ['SUPERADMIN', 'ADMIN'],


### PR DESCRIPTION
- Add explicit block for /admin/newsroom with empty allowed roles array
- This prevents SUPERADMIN from accessing old /admin/newsroom/* paths
- The paths were being allowed because they matched /admin permission
- Root cause: Next.js router prefetching non-existent routes from dashboard

🤖 Generated with [Claude Code](https://claude.ai/code)